### PR TITLE
Allows for Searching Issues by their Tags

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -62,6 +62,7 @@ class IssuesController < ApplicationController
       redirect_to new_user_session_path, notice: "You must be logged in to create an issue."
     end
     @title = "Create an Issue"
+    @availableTags = AllTags.find(:all,:order => "tag")
     @issue = Issue.new
   end
 
@@ -79,12 +80,7 @@ class IssuesController < ApplicationController
           tag = Tag.new
           tag.label = k
           tag.issue_id = @issue.id
-          p tag
-          if tag.save
-            p 'YEsssssssssssssssssssssssssssssss'
-          else
-            p 'noooooooooooooooooooooooooooooooooooooooo'
-          end
+          tag.save
         end
       end
       flash[:notice] = "Your Issue was Added"

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -22,8 +22,24 @@ class IssuesController < ApplicationController
         @start = @start -1
       end
     end
-
-    @openIssues = Issue.find(:all, :limit => 5,:offset => 5*(@page-1), :conditions => ["resolved = ?", 0], :order => "created_at")
+    if (params[:tags] == nil)
+        @openIssues = Issue.find(:all, :limit => 5,:offset => 5*(@page-1), :conditions => ["resolved = ?", 0], :order => "created_at")
+    else
+      tags = []
+      tagCount = 0
+      params[:tags].each_pair do |k,v|
+        if v == "1"
+          tags.push(k)
+          tagCount = tagCount + 1
+        end
+      end
+      if tags.empty?
+        @openIssues = Issue.find(:all, :limit => 5,:offset => 5*(@page-1), :conditions => ["resolved = ?", 0], :order => "created_at")
+      else
+        @selectedIssues = Issue.from("tags, issues").where("tags.issue_id = issues.id and tags.label in (?)",tags).group("issues.id").having("count(issues.id)=?",tagCount)
+        @openIssues = @selectedIssues.find(:all, :limit => 5,:offset => 5*(@page-1), :conditions => ["resolved = ?", 0], :order => "created_at")
+      end
+    end
   end
 
     #displays a specfic issue 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,11 +6,7 @@ class ProjectsController < ApplicationController
     @openIssues = Issue.find(:all, :limit => 10, :conditions => ["resolved = ? AND project_id = ?", 0, @project.slug], :order => "created_at")
     @pendingIssues = Issue.find(:all, :limit => 10, :conditions => ["resolved = ? AND project_id = ?", 1, @project.slug], :order => "created_at")
     @resolvedIssues = Issue.find(:all, :limit => 10, :conditions => ["resolved = ? AND project_id = ?", 2, @project.slug], :order => "created_at")
-    # if not (current_user.admin? or (@project.user_id and current_user.id == @project.user.id))
-    #   @canEdit = false 
-    # else
-    #   @canEdit = true 
-    # end
+
   end
 
   def index 

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -1,3 +1,15 @@
 module IssuesHelper
-
+	def printTags(issue)
+		tags = Tag.where("issue_id = ?", issue.id)
+		allTags = ""
+		tags.each  do |tag|
+			allTags = allTags + ", #" +tag.label
+		end
+		if allTags.length == 0
+			allTags = "None"
+		else
+			allTags = allTags[2..allTags.length]
+		end
+		return allTags
+	end
 end

--- a/app/models/all_tags.rb
+++ b/app/models/all_tags.rb
@@ -1,0 +1,6 @@
+class AllTags < ActiveRecord::Base
+  attr_accessible :tag
+  validates_uniqueness_of :tag
+  validates :tag, :presence => true,
+  					:length => { :maximum => 10 }
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,5 +1,6 @@
 class Issue < ActiveRecord::Base
   belongs_to :project
+  has_many :tags
   attr_accessible :description, :resolved, :title
 
   validates :title, :presence => true,

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ActiveRecord::Base
+  attr_accessible :issue_id, :label
+  belongs_to :issue
+end

--- a/app/views/issues/_form.html.haml
+++ b/app/views/issues/_form.html.haml
@@ -10,11 +10,4 @@
 Select Tags
 %br
 %br
-= check_box :tags, :html, :style => "float:left;"
-= label :tags, :html, 'html'
-
-= check_box :tags, :css, :style => "float:left;"
-= label :tags, :css, 'css'
-
-= check_box :tags, :backend, :style => "float:left;"
-= label :tags, :backend, 'backend'
+= render 'search_form'

--- a/app/views/issues/_form.html.haml
+++ b/app/views/issues/_form.html.haml
@@ -7,3 +7,14 @@
 %br
 = text_area :issue, :description
 %br
+Select Tags
+%br
+%br
+= check_box :tags, :html, :style => "float:left;"
+= label :tags, :html, 'html'
+
+= check_box :tags, :css, :style => "float:left;"
+= label :tags, :css, 'css'
+
+= check_box :tags, :backend, :style => "float:left;"
+= label :tags, :backend, 'backend'

--- a/app/views/issues/_search_form.html.haml
+++ b/app/views/issues/_search_form.html.haml
@@ -1,0 +1,8 @@
+= check_box :tags, :html, :style => "float:left;"
+= label :tags, :html, 'html'
+
+= check_box :tags, :css, :style => "float:left;"
+= label :tags, :css, 'css'
+
+= check_box :tags, :backend, :style => "float:left;"
+= label :tags, :backend, 'backend'

--- a/app/views/issues/_search_form.html.haml
+++ b/app/views/issues/_search_form.html.haml
@@ -1,8 +1,3 @@
-= check_box :tags, :html, :style => "float:left;"
-= label :tags, :html, 'html'
-
-= check_box :tags, :css, :style => "float:left;"
-= label :tags, :css, 'css'
-
-= check_box :tags, :backend, :style => "float:left;"
-= label :tags, :backend, 'backend'
+-@availableTags.each do |tagName|
+  = check_box :tags, tagName.tag, :style => "float:left;"
+  = label :tags, tagName.tag, "#{tagName.tag}"

--- a/app/views/issues/_search_form.html.haml
+++ b/app/views/issues/_search_form.html.haml
@@ -1,3 +1,11 @@
 -@availableTags.each do |tagName|
-  = check_box :tags, tagName.tag, :style => "float:left;"
-  = label :tags, tagName.tag, "#{tagName.tag}"
+  -if params[:tags] == nil
+    = check_box :tags, tagName.tag, :style => "float:left;"
+    = label :tags, tagName.tag, "#{tagName.tag}"
+  -else
+    -if params[:tags][tagName.tag] == "1"
+      = check_box :tags, tagName.tag, :checked => true, :style => "float:left;"
+      = label :tags, tagName.tag, "#{tagName.tag}"
+    -else
+      = check_box :tags, tagName.tag, :style => "float:left;"
+      = label :tags, tagName.tag, "#{tagName.tag}"

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -3,8 +3,9 @@
   %small{:id => "openSearch"}
     %a{:class=>"btn btn-primary", :href=>"#"} Search
 %div{:id => "search-issues-box", :style => "display: none"}
-  We are Searching
-  %a{:class=>"btn btn-primary", :href=>"#"} Search
+  = form_tag issues_path(), :method => "get" do
+    = render 'search_form'
+    = submit_tag 'Begin Search'
 - @openIssues.each do |issue|
   #issue
     .row-fluid
@@ -20,9 +21,6 @@
     .row-fluid
       .tags
         %b.p Tags:
-        \#Java
-        \#html
-        \#css
-        \#saas
+        = printTags(issue)
 =render :partial => 'shared/pagination'
 

--- a/app/views/shared/_pagination.html.haml
+++ b/app/views/shared/_pagination.html.haml
@@ -5,7 +5,7 @@
         %a{:ref=>"#"} Prev
     -else
       %li
-        = link_to "Prev", issues_path(:pageNum => @page-1)
+        = link_to "Prev", issues_path(:pageNum => @page-1, :tags => params[:tags])
 
     -while @start < @end
       -if @start == @page
@@ -13,7 +13,7 @@
           %a{:ref=>"#"}=@start
       -else
         %li
-          = link_to "#{@start}", issues_path(:pageNum => @start)
+          = link_to "#{@start}", issues_path(:pageNum => @start, :tags => params[:tags])
       -@start = @start + 1
 
     -if @page == @end - 1
@@ -21,4 +21,4 @@
         %a{:ref=>"#"} Next
     -else
       %li
-        = link_to "Next", issues_path(:pageNum => @page+1)
+        = link_to "Next", issues_path(:pageNum => @page+1, :tags => params[:tags])

--- a/app/views/shared/_pagination.html.haml
+++ b/app/views/shared/_pagination.html.haml
@@ -16,7 +16,7 @@
           = link_to "#{@start}", issues_path(:pageNum => @start, :tags => params[:tags])
       -@start = @start + 1
 
-    -if @page == @end - 1
+    -if @page == @end - 1 || @page == @end
       %li.disabled
         %a{:ref=>"#"} Next
     -else

--- a/db/migrate/20130409033156_create_tags.rb
+++ b/db/migrate/20130409033156_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration
+  def change
+    create_table :tags do |t|
+      t.string :label
+      t.integer :issue_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20130411050704_create_all_tags.rb
+++ b/db/migrate/20130411050704_create_all_tags.rb
@@ -1,0 +1,9 @@
+class CreateAllTags < ActiveRecord::Migration
+  def change
+    create_table :all_tags do |t|
+      t.string :tag
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130406022218) do
+ActiveRecord::Schema.define(:version => 20130409033156) do
 
   create_table "issues", :force => true do |t|
     t.string   "title"
@@ -51,6 +51,13 @@ ActiveRecord::Schema.define(:version => 20130406022218) do
   create_table "questions", :force => true do |t|
     t.string   "question"
     t.string   "input_type"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "tags", :force => true do |t|
+    t.string   "label"
+    t.integer  "issue_id"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,13 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130409033156) do
+ActiveRecord::Schema.define(:version => 20130411050704) do
+
+  create_table "all_tags", :force => true do |t|
+    t.string   "tag"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
 
   create_table "issues", :force => true do |t|
     t.string   "title"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,3 +17,21 @@ Question.create([
     input_type: "text"
   }
 ])
+
+AllTags.create([
+	{ tag: "backend" },
+	{ tag: "frontend" },
+	{ tag: "css" },
+	{ tag: "ruby" },
+	{ tag: "java" },
+	{ tag: "mobile" },
+	{ tag: "algorithms" },
+	{ tag: "html" },
+	{ tag: "haml" },
+	{ tag: "erb" }
+	])
+
+
+
+
+

--- a/spec/factories/all_tags.rb
+++ b/spec/factories/all_tags.rb
@@ -1,0 +1,7 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :all_tag, :class => 'AllTags' do
+    tag "MyString"
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,8 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :tag do
+    label "MyString"
+    issue_id 1
+  end
+end

--- a/spec/models/all_tags_spec.rb
+++ b/spec/models/all_tags_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe AllTags do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Tag do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Added a Issue search view that displays all issues. You can also search issues by their tags. Added two new tables: one that stores tags for each issue and one that stores all available tags to choose from. 
