### PR TITLE
Add admins

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -43,13 +43,22 @@ class ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     if user_signed_in? and (current_user.admin? or (@project.user_id and current_user.id == @project.user.id))
       if @project.update_attributes(params[:project])
-        redirect_to @project, notice: 'Project was successfully updated.' 
+        if not params[:project][:approved].nil?
+          if params[:project][:approved] == "true"
+            UserMailer.project_approved(@project).deliver
+          else
+            UserMailer.project_denied(@project).deliver
+          end
+        else
+          flash[:notice] = "Project was successfully updated."
+        end
+        redirect_to @project 
       else
         render action: "edit" 
       end
-      else
+    else
         redirect_to @project, notice: 'You do not have permission to edit this project.'
-    end
+    end 
   end
 
   def destroy

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -12,4 +12,41 @@ class UserController < ApplicationController
     @unapproved_projects = Project.unapproved_projects
     @denied_projects = Project.denied_projects
   end
+
+  def add_admin
+    if params[:commit] == "Add"
+      create_admin(params[:user][:email])
+    elsif params[:commit] == "View All"
+      view_all_admins
+    end
+  end
+
+  def create_admin(email)
+    @email = email
+    @user = User.find_by_email(@email)
+    if @user and not @user.admin?
+      @user.update_attributes(:admin=>true)
+      redirect_to user_settings_path, notice: "#{@user.fname} #{@user.lname} is now an admin."      
+    elsif @user and @user.admin?
+      redirect_to user_settings_path, notice: "#{@user.fname} #{@user.lname} is already an admin."      
+    else
+      flash[:error] =  "#{@email} does not exist. Would you like to create a user?"
+      redirect_to user_settings_path    
+    end
+  end
+
+  def view_all_admins
+    @all_admins = User.find_all_by_admin(true)
+  end
+
+  def remove_admin
+    @user = User.find_by_id(params[:id])
+    if @user and @user.admin?
+      @user.update_attributes(:admin=>false)
+      redirect_to user_settings_path, notice: "#{@user.fname} #{@user.lname} is no longer an admin."
+    else
+      flash[:error] = "Your action is invalid."
+      redirect_to user_settings_path
+    end
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,15 @@
+class UserMailer < ActionMailer::Base
+  default from: "support@projectportal.com"
+
+  def project_approved(project)
+    @project = project 
+    @user = User.find_by_id(@project.user_id)
+    mail(:to => @user.email, :subject => "[Project Portal] Your project has been approved!")
+  end
+
+  def project_denied(project)
+    @project = project    
+    @user = User.find_by_id(@project.user_id)
+    mail(:to => @user.email, :subject => "[Project Portal] There were some issues with your project.")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,11 +2,11 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable
 
   # Setup accessible (or protected) attributes for your model
-  attr_accessible :email, :password, :password_confirmation, :remember_me, :admin
+  attr_accessible :fname, :lname, :email, :password, :password_confirmation, :remember_me, :admin
   # attr_accessible :title, :body
 
   has_many :projects, :dependent => :destroy

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @resource.email %>!</p>
+<p>Welcome to Project Portal, <%= @resource.fname %> <%= @resource.lname %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>Please click on the link below to confirm your account email:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token) %></p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,11 +4,11 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
-    <%= f.input :email, :required => true, :autofocus => true %>
-    <%= f.input :fname, :label => "First Name", :required => true %>
-    <%= f.input :lname, :label => "Last Name", :required => true %>
-    <%= f.input :password, :required => true %>
-    <%= f.input :password_confirmation, :required => true %>
+    <%= f.input :email, :label => false, :required => true, :placeholder=> "Email", :autofocus => true %>
+    <%= f.input :fname, :label => false, :placeholder => "First Name", :required => true %>
+    <%= f.input :lname, :label => false, :placeholder => "Last Name", :required => true %>
+    <%= f.input :password, :label => false, :placeholder => "Password", :required => true %>
+    <%= f.input :password_confirmation, :label => false, :placeholder => "Password Confirmation", :required => true %>
   </div>
 
   <div class="form-actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,8 @@
 
   <div class="form-inputs">
     <%= f.input :email, :required => true, :autofocus => true %>
+    <%= f.input :fname, :label => "First Name", :required => true %>
+    <%= f.input :lname, :label => "Last Name", :required => true %>
     <%= f.input :password, :required => true %>
     <%= f.input :password_confirmation, :required => true %>
   </div>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,7 +24,9 @@
                   Account 
                   %b.caret
                 %ul{:class=>"dropdown-menu pull-right"}
-                  %li= link_to 'Settings', user_settings_path 
+                  -if current_user.admin?
+                    %li= link_to 'Admin', user_admin_dashboard_path
+                  %li= link_to 'Settings', edit_user_registration_path
                   %li= link_to 'Logout', destroy_user_session_path, :method => :delete
 
             - else

--- a/app/views/user/_createadmins.html.haml
+++ b/app/views/user/_createadmins.html.haml
@@ -1,0 +1,8 @@
+%h4.details-title
+  Add an Administrator
+=form_tag add_admin_path do
+  =text_field :user, :email, :placeholder => "User Email", :style=>"margin: 0px", :class => "input-medium"
+  =submit_tag 'Add', :class => "btn"
+  =submit_tag 'View All', :class => "btn"
+
+

--- a/app/views/user/_createadmins.html.haml
+++ b/app/views/user/_createadmins.html.haml
@@ -1,7 +1,7 @@
 %h4.details-title
   Add an Administrator
 =form_tag add_admin_path do
-  =text_field :user, :email, :placeholder => "User Email", :style=>"margin: 0px", :class => "input-medium"
+  =text_field_tag :user, "", :style=>"margin: 0px", :class => "input-medium", :data => {:provide=>"typeahead", :items=>"3", :source=>"#{@emails.to_json}"}
   =submit_tag 'Add', :class => "btn"
   =submit_tag 'View All', :class => "btn"
 

--- a/app/views/user/add_admin.html.haml
+++ b/app/views/user/add_admin.html.haml
@@ -1,0 +1,23 @@
+%h1
+  All Administrators
+%table.table.table-striped
+  %tr
+    %td
+      Name
+    %td
+      Email
+    %td
+      Member Since
+    %td
+  - if @all_admins
+    - @all_admins.each do |a|
+      %tr
+        %td
+          #{a.fname} #{a.lname}
+        %td
+          #{a.email}
+        %td
+          #{a.created_at.strftime("%b. %e, %Y,  %l:%M%p")}
+        %td
+          =button_to("Remove", remove_admin_path(a), :class=>"btn btn-danger btn-small")
+

--- a/app/views/user/admin_dashboard.html.haml
+++ b/app/views/user/admin_dashboard.html.haml
@@ -1,0 +1,10 @@
+.row-fluid
+  -if current_user.admin?
+    .span4
+      %h4.details-title
+        Project Form Questions
+      =render :partial => 'questions/question_list'
+    .span8
+      =render :partial => 'createadmins'
+      =render :partial => 'projects/unapproved_list', :locals => {:unapproved_projects => @unapproved_projects,  :denied_projects => @denied_projects}
+      

--- a/app/views/user/settings.html.haml
+++ b/app/views/user/settings.html.haml
@@ -2,13 +2,4 @@
   .span12
     .hero-section
       =link_to "Manage My Account", edit_user_registration_path 
-.row-fluid
-  -if current_user.admin?
-    .span4
-      %h4.details-title
-        Project Form Questions
-      =render :partial => 'questions/question_list'
-    .span8
-      =render :partial => 'createadmins'
-      =render :partial => 'projects/unapproved_list', :locals => {:unapproved_projects => @unapproved_projects,  :denied_projects => @denied_projects}
-      
+     

--- a/app/views/user/settings.html.haml
+++ b/app/views/user/settings.html.haml
@@ -9,4 +9,6 @@
         Project Form Questions
       =render :partial => 'questions/question_list'
     .span8
+      =render :partial => 'createadmins'
       =render :partial => 'projects/unapproved_list', :locals => {:unapproved_projects => @unapproved_projects,  :denied_projects => @denied_projects}
+      

--- a/app/views/user_mailer/project_approved.html.haml
+++ b/app/views/user_mailer/project_approved.html.haml
@@ -1,0 +1,10 @@
+%p
+  Dear #{@user.fname} #{@user.lname},
+
+%p
+  Thank you for submitting your project, #{@project.title}, to Project Portal! Your project has been approved and is ready to begin accepting issues. You many view your project at #{project_path(@project.id)}. We hope you enjoy using Project Portal!
+
+%p
+  Sincerely,
+  %br
+  The Project Portal Team

--- a/app/views/user_mailer/project_denied.html.haml
+++ b/app/views/user_mailer/project_denied.html.haml
@@ -1,0 +1,10 @@
+%p
+  Dear #{@user.fname} #{@user.lname},
+
+%p
+  Thank you for submitting your project, #{@project.title}, to Project Portal. Unfortunally your project was not accepted. If you would like to discuss why and how you should resubmit your project, please contact us at support@projectportal.com. We welcome you to submit another project in the near future.
+
+%p
+  Sincerely,
+  %br
+  The Project Portal Team

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,4 +36,7 @@ ProjectPortal::Application.configure do
   config.assets.debug = true
 
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
+
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "support@projectportal.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ ProjectPortal::Application.routes.draw do
   match 'projects/:id/user_edit' => 'projects#user_edit', :as => :user_edit_project
   get "user/show"
   get "user/settings"
+  get "user/admin_dashboard"
   match 'dashboard' => 'user#show', :as => :dashboard
 
   match 'admins/manage' => 'user#add_admin', :as => :add_admin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,10 @@ ProjectPortal::Application.routes.draw do
   get "user/settings"
   match 'dashboard' => 'user#show', :as => :dashboard
 
+  match 'admins/manage' => 'user#add_admin', :as => :add_admin
+  match 'admins/remove/:id' => 'user#remove_admin', :as => :remove_admin
+
+  
   # The priority is based upon order of creation:
   # first created -> highest priority.
 

--- a/db/migrate/20130415144159_add_confirmable_to_users.rb
+++ b/db/migrate/20130415144159_add_confirmable_to_users.rb
@@ -1,0 +1,11 @@
+class AddConfirmableToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string # for reconfirmable
+    add_index :users, :confirmation_token, :unique => true
+
+    User.update_all(:confirmed_at => Time.now)
+  end
+end

--- a/db/migrate/20130415150350_add_first_and_last_name_to_users.rb
+++ b/db/migrate/20130415150350_add_first_and_last_name_to_users.rb
@@ -1,0 +1,7 @@
+class AddFirstAndLastNameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :fname, :string
+    add_column :users, :lname, :string
+    User.update_all(:fname => "John", :lname => "Doe")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130411050704) do
+ActiveRecord::Schema.define(:version => 20130415150350) do
 
   create_table "all_tags", :force => true do |t|
     t.string   "tag"
@@ -82,8 +82,15 @@ ActiveRecord::Schema.define(:version => 20130411050704) do
     t.datetime "created_at",                                :null => false
     t.datetime "updated_at",                                :null => false
     t.boolean  "admin",                  :default => false
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
+    t.string   "fname"
+    t.string   "lname"
   end
 
+  add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true
   add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "spec_helper"
+
+describe UserMailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- added a "add admins" feature to the admin dashboard page
- moved the admin dashboards page from the user settings page to its own page
- added email confirmation at account creation
- added email notification when a project is approved or denied

todo: 
- refactor admins so admin access to pages is more clean/secure
- add email confirmation to when project is favorited
- add "do not notify when project is favorited" to settings
