### PR TITLE
fix spacing on project description inconsistency

### DIFF
--- a/app/views/shared/_project_description.html.haml
+++ b/app/views/shared/_project_description.html.haml
@@ -27,7 +27,7 @@
       %a.btn-link{id: "long_description#{project.id}"}
         %i.icon-pencil
     -else
-      %p=project.long_description
+      =project.long_description
 
 
 


### PR DESCRIPTION
just made long description on the project description formatted the same as the rest of the page
